### PR TITLE
Add exact amount check to `sendETH`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+artifacts/
+cache/
+dist/
+typechain-types/
+deployments/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "semi": false,
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "tabWidth": 4,
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/contracts/MultiSender.sol
+++ b/contracts/MultiSender.sol
@@ -12,7 +12,7 @@ contract MultiSender is Initializable {
     function initialize() public initializer {}
 
     // Event definitions
-    event SendETH(address token, address[] recipients, uint256[] amounts);
+    event SendETH(address[] recipients, uint256[] amounts);
     event SendERC20(address token, address[] recipients, uint256[] amounts);
 
     // Function to send ETH to multiple recipients
@@ -35,7 +35,7 @@ contract MultiSender is Initializable {
         }
 
         // Emit the SendETH event
-        emit SendETH(address(0), _recipients, _amounts);
+        emit SendETH(_recipients, _amounts);
     }
 
     // Function to send ERC20 tokens to multiple recipients

--- a/contracts/MultiSender.sol
+++ b/contracts/MultiSender.sol
@@ -43,7 +43,7 @@ contract MultiSender is Initializable {
         address _token,
         address[] calldata _recipients,
         uint256[] calldata _amounts
-    ) external payable {
+    ) external {
         // Check if the lengths of recipients and amounts arrays are equal
         require(_recipients.length == _amounts.length, "Must have the same length");
 

--- a/contracts/MultiSender.sol
+++ b/contracts/MultiSender.sol
@@ -16,15 +16,9 @@ contract MultiSender is Initializable {
     event SendERC20(address token, address[] recipients, uint256[] amounts);
 
     // Function to send ETH to multiple recipients
-    function sendETH(
-        address[] calldata _recipients,
-        uint256[] calldata _amounts
-    ) external payable {
+    function sendETH(address[] calldata _recipients, uint256[] calldata _amounts) external payable {
         // Check if the lengths of recipients and amounts arrays are equal
-        require(
-            _recipients.length == _amounts.length,
-            "Must have the same length"
-        );
+        require(_recipients.length == _amounts.length, "Must have the same length");
 
         // Calculate the total amount to be sent
         uint256 totalAmount = 0;
@@ -33,7 +27,7 @@ contract MultiSender is Initializable {
         }
 
         // Check if the sender has enough ETH
-        require(msg.value >= totalAmount, "Not enough ETH");
+        require(msg.value == totalAmount, "Unequal transfer amount");
 
         // Send ETH to recipients
         for (uint256 i = 0; i < _recipients.length; i++) {
@@ -51,10 +45,7 @@ contract MultiSender is Initializable {
         uint256[] calldata _amounts
     ) external payable {
         // Check if the lengths of recipients and amounts arrays are equal
-        require(
-            _recipients.length == _amounts.length,
-            "Must have the same length"
-        );
+        require(_recipients.length == _amounts.length, "Must have the same length");
 
         // Calculate the total amount to be sent
         uint256 totalAmount = 0;
@@ -66,10 +57,7 @@ contract MultiSender is Initializable {
         IERC20Upgradeable token = IERC20Upgradeable(_token);
 
         // Check if the sender has enough tokens
-        require(
-            token.balanceOf(msg.sender) >= totalAmount,
-            "Not enough tokens"
-        );
+        require(token.balanceOf(msg.sender) >= totalAmount, "Not enough tokens");
 
         // Send tokens to each recipient
         for (uint256 i = 0; i < _recipients.length; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "multisend",
+  "name": "multisend_bayram",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -23,7 +23,7 @@
         "chai": "^4.2.0",
         "dotenv": "^16.0.1",
         "ethers": "^5.4.7",
-        "hardhat": "^2.10.1",
+        "hardhat": "^2.22.5",
         "hardhat-gas-reporter": "^1.0.8",
         "solidity-coverage": "^0.7.21",
         "ts-node": ">=8.0.0",
@@ -1030,28 +1030,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.8.tgz",
-      "integrity": "sha512-u2UJ5QpznSHVkZRh6ePWoeVb6kmPrrqh08gCnZ9FHlJV9CITqlrTQHJkacd+INH31jx88pTAJnxePE4XAiH5qg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.0.tgz",
+      "integrity": "sha512-T96DMSogO8TCdbKKctvxfsDljbhFOUKWc9fHJhSeUh71EEho2qR4951LKQF7t7UWEzguVYh/idQr5L/E3QeaMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.3.8",
-        "@nomicfoundation/edr-darwin-x64": "0.3.8",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.3.8",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.3.8",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.3.8",
-        "@nomicfoundation/edr-linux-x64-musl": "0.3.8",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.3.8"
+        "@nomicfoundation/edr-darwin-arm64": "0.4.0",
+        "@nomicfoundation/edr-darwin-x64": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-musl": "0.4.0",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.4.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.8.tgz",
-      "integrity": "sha512-eB0leCexS8sQEmfyD72cdvLj9djkBzQGP4wSQw6SNf2I4Sw4Cnzb3d45caG2FqFFjbvfqL0t+badUUIceqQuMw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-7+rraFk9tCqvfemv9Ita5vTlSBAeO/S5aDKOgGRgYt0JEKZlrX161nDW6UfzMPxWl9GOLEDUzCEaYuNmXseUlg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.8.tgz",
-      "integrity": "sha512-JksVCS1N5ClwVF14EvO25HCQ+Laljh/KRfHERMVAC9ZwPbTuAd/9BtKvToCBi29uCHWqsXMI4lxCApYQv2nznw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-+Hrc0mP9L6vhICJSfyGo/2taOToy1AIzVZawO3lU8Lf7oDQXfhQ4UkZnkWAs9SVu1eUwHUGGGE0qB8644piYgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.8.tgz",
-      "integrity": "sha512-raCE+fOeNXhVBLUo87cgsHSGvYYRB6arih4eG6B9KGACWK5Veebtm9xtKeiD8YCsdUlUfat6F7ibpeNm91fpsA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-4HUDMchNClQrVRfVTqBeSX92hM/3khCgpZkXP52qrnJPqgbdCxosOehlQYZ65wu0b/kaaZSyvACgvCLSQ5oSzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.8.tgz",
-      "integrity": "sha512-PwiDp4wBZWMCIy29eKkv8moTKRrpiSDlrc+GQMSZLhOAm8T33JKKXPwD/2EbplbhCygJDGXZdtEKl9x9PaH66A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-D4J935ZRL8xfnP3zIFlCI9jXInJ0loDUkCTLeCEbOf2uuDumWDghKNQlF1itUS+EHaR1pFVBbuwqq8hVK0dASg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.8.tgz",
-      "integrity": "sha512-6AcvA/XKoipGap5jJmQ9Y6yT7Uf39D9lu2hBcDCXnXbMcXaDGw4mn1/L4R63D+9VGZyu1PqlcJixCUZlGGIWlg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-6x7HPy+uN5Cb9N77e2XMmT6+QSJ+7mRbHnhkGJ8jm4cZvWuj2Io7npOaeHQ3YHK+TiQpTnlbkjoOIpEwpY3XZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.8.tgz",
-      "integrity": "sha512-cxb0sEmZjlwhYWO28sPsV64VDx31ekskhC1IsDXU1p9ntjHSJRmW4KEIqJ2O3QwJap/kLKfMS6TckvY10gjc6w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-3HFIJSXgyubOiaN4MWGXx2xhTnhwlJk0PiSYNf9+L/fjBtcRkb2nM910ZJHTvqCb6OT98cUnaKuAYdXIW2amgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.8.tgz",
-      "integrity": "sha512-yVuVPqRRNLZk7TbBMkKw7lzCvI8XO8fNTPTYxymGadjr9rEGRuNTU1yBXjfJ59I1jJU/X2TSkRk1OFX0P5tpZQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-CP4GsllEfXEz+lidcGYxKe5rDJ60TM5/blB5z/04ELVvw6/CK9eLcYeku7HV0jvV7VE6dADYKSdQyUkvd0El+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6430,15 +6430,15 @@
       "license": "MIT"
     },
     "node_modules/hardhat": {
-      "version": "2.22.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.4.tgz",
-      "integrity": "sha512-09qcXJFBHQUaraJkYNr7XlmwjOj27xBB0SL2rYS024hTj9tPMbp26AFjlf5quBMO9SR4AJFg+4qWahcYcvXBuQ==",
+      "version": "2.22.5",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.5.tgz",
+      "integrity": "sha512-9Zq+HonbXCSy6/a13GY1cgHglQRfh4qkzmj1tpPlhxJDwNVnhxlReV6K7hCWFKlOrV13EQwsdcD0rjcaQKWRZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/edr": "^0.3.7",
+        "@nomicfoundation/edr": "^0.4.0",
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-tx": "5.0.4",
         "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^4.2.0",
     "dotenv": "^16.0.1",
     "ethers": "^5.4.7",
-    "hardhat": "^2.10.1",
+    "hardhat": "^2.22.5",
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.7.21",
     "ts-node": ">=8.0.0",

--- a/test/deployAndTransfer.ts
+++ b/test/deployAndTransfer.ts
@@ -1,78 +1,110 @@
-import { ethers } from 'hardhat';
-import { expect } from 'chai';
+import { ethers } from 'hardhat'
+import { expect } from 'chai'
 
-describe('MultiSender', function () {
+describe('MultiSender', async function () {
+  let multiSender
+  let sender, recipient1, recipient2, recipient3
 
-    it('Should send ETH correctly', async function () {
-        // Deploy the contract
-        const MultiSender = await ethers.getContractFactory('MultiSender');
-        const multiSender = await MultiSender.deploy();
-        await multiSender.deployed();
-        
-        // Get test accounts
-        const [sender, recipient1, recipient2, recipient3] = await ethers.getSigners();
-    
-        const initialBalance = await ethers.provider.getBalance(sender.address);
-        console.log('Initial Balance:', ethers.utils.formatEther(initialBalance));
+  beforeEach(async function () {
+    // Deploy the contract
+    const MultiSender = await ethers.getContractFactory('MultiSender')
+    multiSender = await MultiSender.deploy()
+    await multiSender.deployed()
+    ;[sender, recipient1, recipient2, recipient3] = await ethers.getSigners()
+  })
 
-        const beforeBalance1 = await ethers.provider.getBalance(recipient1.address);
-        const beforeBalance2 = await ethers.provider.getBalance(recipient2.address);
-        const beforeBalance3 = await ethers.provider.getBalance(recipient3.address);
+  it('Should sendETH correctly', async function () {
+    const initialBalance = await ethers.provider.getBalance(sender.address)
+    console.log('Initial Balance:', ethers.utils.formatEther(initialBalance))
 
-        await multiSender.sendETH(
-          [recipient1.address, recipient2.address, recipient3.address],
-          [ethers.utils.parseEther('1'), ethers.utils.parseEther('2'), ethers.utils.parseEther('3')]
-        , { value: ethers.utils.parseEther("6") });
-    
-        expect((await ethers.provider.getBalance(recipient1.address)).toString()).to.equal(beforeBalance1.add(ethers.utils.parseEther('1')).toString());
-        expect((await ethers.provider.getBalance(recipient2.address)).toString()).to.equal(beforeBalance2.add(ethers.utils.parseEther('2')).toString());
-        expect((await ethers.provider.getBalance(recipient3.address)).toString()).to.equal(beforeBalance3.add(ethers.utils.parseEther('3')).toString());    
-      });
+    const beforeBalance1 = await ethers.provider.getBalance(recipient1.address)
+    const beforeBalance2 = await ethers.provider.getBalance(recipient2.address)
+    const beforeBalance3 = await ethers.provider.getBalance(recipient3.address)
 
-    it('Should send tokens correctly', async function () {
-        // Deploy the contract
-        const MultiSender = await ethers.getContractFactory('MultiSender');
-        const multiSender = await MultiSender.deploy();
-        await multiSender.deployed();
+    await multiSender.sendETH(
+      [recipient1.address, recipient2.address, recipient3.address],
+      [ethers.utils.parseEther('1'), ethers.utils.parseEther('2'), ethers.utils.parseEther('3')],
+      { value: ethers.utils.parseEther('6') }
+    )
 
-        // Get test accounts
-        const [sender, recipient1, recipient2, recipient3] = await ethers.getSigners();
+    expect((await ethers.provider.getBalance(recipient1.address)).toString()).to.equal(
+      beforeBalance1.add(ethers.utils.parseEther('1')).toString()
+    )
+    expect((await ethers.provider.getBalance(recipient2.address)).toString()).to.equal(
+      beforeBalance2.add(ethers.utils.parseEther('2')).toString()
+    )
+    expect((await ethers.provider.getBalance(recipient3.address)).toString()).to.equal(
+      beforeBalance3.add(ethers.utils.parseEther('3')).toString()
+    )
+  })
 
-        // Mint some tokens for the sender
-        const Token = await ethers.getContractFactory("Token");
-        const token = await Token.deploy(ethers.utils.parseEther('100'));
-        await token.deployed();
+  it('Should sendETH fail when the total amount is not equal to the sent amount', async function () {
+    // Test when total amount is less than the sent amount
+    await expect(
+      multiSender.sendETH(
+        [recipient1.address, recipient2.address, recipient3.address],
+        [ethers.utils.parseEther('1'), ethers.utils.parseEther('2'), ethers.utils.parseEther('3')],
+        { value: ethers.utils.parseEther('5') } //
+      )
+    ).to.be.rejectedWith('Unequal transfer amount')
 
-        const totalSupply = await token.totalSupply();
-        console.log('Total Supply:', ethers.utils.formatEther(totalSupply));
+    // Test when total amount is more than the sent amount
+    await expect(
+      multiSender.sendETH(
+        [recipient1.address, recipient2.address, recipient3.address],
+        [ethers.utils.parseEther('1'), ethers.utils.parseEther('2'), ethers.utils.parseEther('3')],
+        { value: ethers.utils.parseEther('7') }
+      )
+    ).to.be.rejectedWith('Unequal transfer amount')
+  })
 
-        const balance1 = await token.balanceOf(sender.address);
-        console.log('Balance:', ethers.utils.formatEther(balance1));
+  it('Should send ERC20 token correctly', async function () {
+    // Mint some tokens for the sender
+    const Token = await ethers.getContractFactory('Token')
+    const token = await Token.deploy(ethers.utils.parseEther('100'))
+    await token.deployed()
 
-        const balanceDeployer = await token.balanceOf(sender.address);
-        console.log('Balance of DeployerAddress:', ethers.utils.formatEther(balanceDeployer));
+    const totalSupply = await token.totalSupply()
+    console.log('Total Supply:', ethers.utils.formatEther(totalSupply))
 
-        await token.transfer(sender.address, ethers.utils.parseEther('100'));
+    const balance1 = await token.balanceOf(sender.address)
+    console.log('Balance:', ethers.utils.formatEther(balance1))
 
-        const balance = await token.balanceOf(sender.address);
-        console.log('Balance:', ethers.utils.formatEther(balance));
+    const balanceDeployer = await token.balanceOf(sender.address)
+    console.log('Balance of DeployerAddress:', ethers.utils.formatEther(balanceDeployer))
 
-        // Approve the MultiSender contract to spend tokens
-        await token.connect(sender).approve(multiSender.address, ethers.utils.parseEther('100'));
+    await token.transfer(sender.address, ethers.utils.parseEther('100'))
 
-        // Check the sender's balance before the transaction
-        const initialBalance = await token.balanceOf(sender.address);
+    const balance = await token.balanceOf(sender.address)
+    console.log('Balance:', ethers.utils.formatEther(balance))
 
-        // Call the multiSend function
-        await multiSender.connect(sender).sendERC20(token.address, [recipient1.address, recipient2.address, recipient3.address], [ethers.utils.parseEther('10'), ethers.utils.parseEther('20'), ethers.utils.parseEther('30')]);
+    // Approve the MultiSender contract to spend tokens
+    await token.connect(sender).approve(multiSender.address, ethers.utils.parseEther('60'))
 
-        // Check the sender's balance after the transaction
-        const finalBalance = await token.balanceOf(sender.address);
-        expect(finalBalance).to.equal(initialBalance.sub(ethers.utils.parseEther('60')));
+    // Check the sender's balance before the transaction
+    const initialBalance = await token.balanceOf(sender.address)
 
-        // Check the recipients' balances
-        expect(await token.balanceOf(recipient1.address)).to.equal(ethers.utils.parseEther('10'));
-        expect(await token.balanceOf(recipient2.address)).to.equal(ethers.utils.parseEther('20'));
-        expect(await token.balanceOf(recipient3.address)).to.equal(ethers.utils.parseEther('30'));
-    });
-});
+    // Call the multiSend function
+    await multiSender
+      .connect(sender)
+      .sendERC20(
+        token.address,
+        [recipient1.address, recipient2.address, recipient3.address],
+        [
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('20'),
+          ethers.utils.parseEther('30')
+        ]
+      )
+
+    // Check the sender's balance after the transaction
+    const finalBalance = await token.balanceOf(sender.address)
+    expect(finalBalance).to.equal(initialBalance.sub(ethers.utils.parseEther('60')))
+
+    // Check the recipients' balances
+    expect(await token.balanceOf(recipient1.address)).to.equal(ethers.utils.parseEther('10'))
+    expect(await token.balanceOf(recipient2.address)).to.equal(ethers.utils.parseEther('20'))
+    expect(await token.balanceOf(recipient3.address)).to.equal(ethers.utils.parseEther('30'))
+  })
+  // TODO(Bayram): Add more tests to check failure conditions for ERC20
+})


### PR DESCRIPTION
## Overview

@Zena-park This PR is ready to review and will solve several issues together, please take a look. After this PR, I will make a new PR to resolve the remaining issues. 

This PR prevents the potential loss of funds by ensuring that the amount of Ether sent exactly equals the total amount to be transferred. It also improves the overall code quality and consistency by introducing Prettier and updating the Hardhat version.

### Changes

- Fix: Added an exact value check to `sendETH` function to prevent excess Ether from being locked in the contract #3 
- Fix: Remove unnecessary `token` parameter from `SendETH` event. #9 
- Fix: Remove payable modifier from `sendERC20` to prevent ETH loss. #5 
- Test: Added a test to check for failed transactions in the `sendETH` function 
- Increase `Hardhat` version
- Added `Prettier` for code formatting and consistency

### Future Work
- Resolve remaining issues 
- Further tests will be added to check failure conditions